### PR TITLE
doc(twitter organic): Fix relative links in Twitter Organic source README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ packages:
 ```
 
 ## Package Maintenance
-The Fivetran team maintaining this package **only** maintains the latest version. We recommend you keep your `packages.yml` updated with the [dbt hub latest version](https://hub.getdbt.com/fivetran/twitter_organic_source/latest/). You may refer to the [CHANGELOG](/CHANGELOG.md) and release notes for more information on changes across versions.
+The Fivetran team maintaining this package **only** maintains the latest version. We recommend you keep your `packages.yml` updated with the [dbt hub latest version](https://hub.getdbt.com/fivetran/twitter_organic_source/latest/). You may refer to the [CHANGELOG](https://github.com/fivetran/dbt_twitter_organic_source/blob/main/CHANGELOG.md) and release notes for more information on changes across versions.
 
 ## Configuration
 By default, this package will look for your Twitter Organic data in the `twitter_organic` schema of your [target database](https://docs.getdbt.com/docs/running-a-dbt-project/using-the-command-line-interface/configure-your-profile). If this is not where your Twitter Organic data is, please add the following configuration to your `dbt_project.yml` file:


### PR DESCRIPTION
Closes https://fivetran.atlassian.net/browse/RD-228387

Replaces relative links (those that assume a `github.com` root) with absolute links, since the relative links do not work when we embed the README on our docs site.